### PR TITLE
Dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushkin-cli",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "A CLI for automating basic Pushkin tasks",
   "main": "build/index.js",
   "files": [

--- a/src/commands/prep/index.js
+++ b/src/commands/prep/index.js
@@ -448,13 +448,14 @@ export default async (experimentsDir, coreDir) => {
     console.error(err);
     process.exit();
   }
-  try {
-    rebuildingServices = exec(`docker-compose -f pushkin/docker-compose.dev.yml build --no-cache --parallel server api`);
-  } catch (err) {
-    console.error('Problem with building local docker images for front-end and/or api. ', err);
-    process.exit();
-  }
+//  try {
+//    rebuildingServices = exec(`docker-compose -f pushkin/docker-compose.dev.yml build --no-cache --parallel server api`);
+//  } catch (err) {
+//    console.error('Problem with building local docker images for front-end and/or api. ', err);
+//    process.exit();
+//  }
 
-  console.log('Rebuilding local docker images. This will take some time. You will need to check Docker to see when it is done, since Docker and Node do not play well together.')
-  return await Promise.all([settingUpDB, rebuildingServices])
+//  console.log('Rebuilding local docker images. This will take some time. You will need to check Docker to see when it is done, since Docker and Node do not play well together.')
+//  return await Promise.all([settingUpDB, rebuildingServices])
+  return await Promise.all([settingUpDB])
 };

--- a/src/index.js
+++ b/src/index.js
@@ -15,9 +15,12 @@ import setupdb from './commands/setupdb/index.js';
 import * as compose from 'docker-compose'
 import { Command } from 'commander'
 import inquirer from 'inquirer'
+const version = require("../package.json").version
+
 
 const program = new Command();
-program.version('0.0.1');
+program.version(version);
+
 
 const moveToProjectRoot = () => {
   // better checking to make sure this is indeed a pushkin project would be goodf

--- a/src/index.js
+++ b/src/index.js
@@ -174,8 +174,17 @@ async function main() {
   program
     .command('start')
     .description('Starts local deploy for debugging purposes. To start only the front end (no databases), see the manual.')
-    .action(() => {
+    .option('-nc, --nocache', 'Rebuild all images from scratch, without using the cache.', false)
+    .action(async (options) => {
       moveToProjectRoot();
+      if (options.nocache){
+        try {
+          await compose.buildAll({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml', log: true, commandOptions: ["--no-cache"]})    
+        } catch (e) {
+          console.error("Problem rebuilding docker images");
+          throw e;
+        }
+      }
       compose.upAll({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml', log: true})
         .then(
           out => { console.log(out.out, 'Starting. You may not be able to load localhost for a minute or two.')},

--- a/src/index.js
+++ b/src/index.js
@@ -222,6 +222,7 @@ async function main() {
       } catch (err) {
         console.err(err);
       }
+      return;
     })
 
    program.parseAsync(process.argv);


### PR DESCRIPTION
* pushkin --version now gives the actual version number
* all docker commands now use the cache by default. This will have limited value without using updated versions of the site template, which has more optimized docker files
* pushkin start now has an optional flag "--nocache" that rebuilds the server and api without using the cache. There is currently no way to force a rebuild-from-scratch for workers, though, without running "pushkin kill"
* pushkin prep no longer builds the docker images for the api or server
