### PR TITLE
V.1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushkin-cli",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A CLI for automating basic Pushkin tasks",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushkin-cli",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A CLI for automating basic Pushkin tasks",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushkin-cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A CLI for automating basic Pushkin tasks",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushkin-cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A CLI for automating basic Pushkin tasks",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushkin-cli",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "A CLI for automating basic Pushkin tasks",
   "main": "build/index.js",
   "files": [

--- a/src/commands/experiments/index.js
+++ b/src/commands/experiments/index.js
@@ -27,7 +27,7 @@ const promiseExpFolderInit = async (initDir, dir, rootDir, modName, buildPath) =
   return new Promise ((resolve, reject) => {
     console.log(`Installing dependencies for ${dir}`);
     try {
-      exec(pacMan.concat(' install'), { cwd: path.join(initDir, dir) })
+      exec(pacMan.concat(' install --mutex network'), { cwd: path.join(initDir, dir) })
         .then(() => {
           console.log(`Building ${modName} from ${dir}`);
           exec(pacMan.concat(' run build'), { cwd: path.join(initDir, dir) })

--- a/src/commands/experiments/index.js
+++ b/src/commands/experiments/index.js
@@ -184,7 +184,7 @@ const initExperiment = async (expDir, expName, longName, rootDir) => {
     console.error("There is already an API controller by the name of ", expName)
     throw new Error("Problem adding API controller to controller list.")
   }
-  controllersJsonFile[contName] = "api/".concat(contName)
+  controllersJsonFile[contName] = "api/".concat(expName)
   try {
    fs.writeFileSync(path.join(rootDir, 'pushkin/api/src/controllers.json'), JSON.stringify(controllersJsonFile), 'utf8')
   } catch (e) {

--- a/src/commands/experiments/templates.js
+++ b/src/commands/experiments/templates.js
@@ -1,3 +1,3 @@
-export const templates = [
-	{name: "basic", url: "https://api.github.com/repos/pushkin-consortium/pushkin-exptemplates-basic/releases/latest"}
-]
+export const templates = {
+	basic: "https://api.github.com/repos/pushkin-consortium/pushkin-exptemplates-basic/releases"
+}

--- a/src/commands/prep/index.js
+++ b/src/commands/prep/index.js
@@ -115,6 +115,12 @@ export default async (experimentsDir, coreDir) => {
 
   const cleanWeb = async (coreDir) => {
     console.log(`resetting experiments.js`); 
+    try {
+      fs.unlink(path.join(coreDir, 'front-end/experiments.js'));
+    } catch (e) {
+      //These extra experiments.js files are created when doing a local test deploy
+      //If it doesn't exist, that's just fine
+    }
     const webPageAttachListFile = path.join(coreDir, 'front-end/src/experiments.js');
     let cleanedWeb
     try {

--- a/src/commands/prep/index.js
+++ b/src/commands/prep/index.js
@@ -430,32 +430,5 @@ export default async (experimentsDir, coreDir) => {
     process.exit()
   }
 
-  console.log('Installing packages. This may take a few minutes.')
-  let anotherAwait = await Promise.all([installedApi, installedWeb])
-
-  let settingUpDB, rebuildingServices, config;
-  try {
-     config = jsYaml.safeLoad(fs.readFileSync(path.join(process.cwd(), 'pushkin.yaml')));
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      console.log('File not found!');
-    }
-    throw err
-  }
-  try {
-    settingUpDB = setupdb(config.databases, experimentsDir);
-  } catch (err) {
-    console.error(err);
-    process.exit();
-  }
-//  try {
-//    rebuildingServices = exec(`docker-compose -f pushkin/docker-compose.dev.yml build --no-cache --parallel server api`);
-//  } catch (err) {
-//    console.error('Problem with building local docker images for front-end and/or api. ', err);
-//    process.exit();
-//  }
-
-//  console.log('Rebuilding local docker images. This will take some time. You will need to check Docker to see when it is done, since Docker and Node do not play well together.')
-//  return await Promise.all([settingUpDB, rebuildingServices])
-  return await Promise.all([settingUpDB])
+  return;
 };

--- a/src/commands/prep/index.js
+++ b/src/commands/prep/index.js
@@ -113,6 +113,26 @@ export default async (experimentsDir, coreDir) => {
 
   console.log("package manager: ",pacMan);
 
+  const cleanWeb = async (coreDir) => {
+    console.log(`resetting experiments.js`); 
+    const webPageAttachListFile = path.join(coreDir, 'front-end/src/experiments.js');
+    let cleanedWeb
+    try {
+      cleanedWeb = fs.promises.writeFile(path.join(coreDir, 'front-end/src/experiments.js'), `[]`, 'utf8')      
+    } catch (e) {
+      console.error('Problem overwriting experiments.js')
+      throw e
+    }
+    return cleanedWeb;
+  }
+
+  let cleanedWeb
+  try {
+    cleanedWeb = cleanWeb(coreDir);
+  } catch (e) {
+    throw e
+  }
+
   const prepAPIWrapper = (exp) => {
     console.log(`Started prepping API for`, exp);
     return new Promise((resolve, reject) => {
@@ -244,15 +264,15 @@ export default async (experimentsDir, coreDir) => {
   }
 
 
-const tempAwait = await Promise.all([webPageIncludes, preppedAPI])
+const tempAwait = await Promise.all([webPageIncludes, preppedAPI, cleanedWeb])
 
   // Deal with Web page includes
-  let finalWebPages = tempAwait[1]
+  let finalWebPages = tempAwait[0]
   let top
   let bottom
   let toWrite
   try {
-console.log("Writing out experiments.js")
+    console.log("Writing out experiments.js")
     top = finalWebPages.map((include) => {return `import ${include.moduleName} from '${include.moduleName}';\n`})
     top = top.join('')
     bottom = finalWebPages.map((include) => {return `${include.listAppendix}\n`}).join(',')

--- a/src/commands/prep/index.js
+++ b/src/commands/prep/index.js
@@ -115,10 +115,10 @@ export default async (experimentsDir, coreDir) => {
 
   const cleanWeb = async (coreDir) => {
     console.log(`resetting experiments.js`); 
-    const webPageAttachListFile = path.join(coreDir, 'front-end/src/experiments.js');
+    const webPageAttachListFile = path.join(coreDir, 'front-end/experiments.js');
     let cleanedWeb
     try {
-      cleanedWeb = fs.promises.writeFile(path.join(coreDir, 'front-end/src/experiments.js'), `[]`, 'utf8')      
+      cleanedWeb = fs.promises.writeFile(path.join(coreDir, 'front-end/experiments.js'), `[]`, 'utf8')      
     } catch (e) {
       console.error('Problem overwriting experiments.js')
       throw e
@@ -277,7 +277,7 @@ const tempAwait = await Promise.all([webPageIncludes, preppedAPI, cleanedWeb])
     top = top.join('')
     bottom = finalWebPages.map((include) => {return `${include.listAppendix}\n`}).join(',')
     toWrite = top.concat(`export default [\n`).concat(bottom).concat(`];`)
-    fs.writeFileSync(path.join(coreDir, 'front-end/src/experiments.js'), toWrite, 'utf8')
+    fs.writeFileSync(path.join(coreDir, 'front-end/experiments.js'), toWrite, 'utf8')
   } catch (e) { 
     console.error('Failed to include web pages in front end');
     throw e; 

--- a/src/commands/prep/index.js
+++ b/src/commands/prep/index.js
@@ -115,10 +115,10 @@ export default async (experimentsDir, coreDir) => {
 
   const cleanWeb = async (coreDir) => {
     console.log(`resetting experiments.js`); 
-    const webPageAttachListFile = path.join(coreDir, 'front-end/experiments.js');
+    const webPageAttachListFile = path.join(coreDir, 'front-end/src/experiments.js');
     let cleanedWeb
     try {
-      cleanedWeb = fs.promises.writeFile(path.join(coreDir, 'front-end/experiments.js'), `[]`, 'utf8')      
+      cleanedWeb = fs.promises.writeFile(path.join(coreDir, 'front-end/src/experiments.js'), `[]`, 'utf8')      
     } catch (e) {
       console.error('Problem overwriting experiments.js')
       throw e
@@ -277,7 +277,7 @@ const tempAwait = await Promise.all([webPageIncludes, preppedAPI, cleanedWeb])
     top = top.join('')
     bottom = finalWebPages.map((include) => {return `${include.listAppendix}\n`}).join(',')
     toWrite = top.concat(`export default [\n`).concat(bottom).concat(`];`)
-    fs.writeFileSync(path.join(coreDir, 'front-end/experiments.js'), toWrite, 'utf8')
+    fs.writeFileSync(path.join(coreDir, 'front-end/src/experiments.js'), toWrite, 'utf8')
   } catch (e) { 
     console.error('Failed to include web pages in front end');
     throw e; 

--- a/src/commands/setupdb/index.js
+++ b/src/commands/setupdb/index.js
@@ -111,7 +111,7 @@ export default async (coreDBs, mainExpDir) => {
       })
       return compose.stop({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml'})
       .then(
-        out => { console.log(out.out, 'done')},
+        out => { console.log(out.out, 'Database updated. Shutting down...')},
         err => { console.log('something went wrong:', err.message)}
       );
 

--- a/src/commands/sites/index.js
+++ b/src/commands/sites/index.js
@@ -13,14 +13,7 @@ import pacMan from '../../pMan.js';  //which package manager is available?
 
 
 export function listSiteTemplates() {
-    return new Promise((resolve, reject) => {
-    try { 
-      resolve(templates.map((t) => (t.name)));
-    } catch (e) { 
-      console.error(`Something is wrong with sites/templates.js, error: ${e}`); 
-      process.exit(); 
-    }
-  })
+  return templates;
 }
 
 export const promiseFolderInit = async (initDir, dir) => {
@@ -43,7 +36,7 @@ export const promiseFolderInit = async (initDir, dir) => {
   })
 }
 
-export async function getPushkinSite(initDir, templateName) {
+export async function getPushkinSite(initDir, url) {
   process.chdir(initDir); // Node command to change directory
 
   const newDirs = ['pushkin', 'experiments'];
@@ -60,26 +53,21 @@ export async function getPushkinSite(initDir, templateName) {
   });
 
   // download files
-  let url;
-  for (const val in templates) {
-    if (templates[val].name == templateName) {
-      url = templates[val].url;
-    }
-  }
   if (!url) {
-    console.error('Unable to download from specified site. Make sure your internet is on. If it is on but this error repeats, ask for help on the Pushkin forum.');
+    console.error('URL is not well-defined.');
     return;
   }
   console.log(`retrieving from ${url}`);
   console.log('be patient...');
   let zipball_url;
+  let response
   try {
-    const response = await got(url);
+    response = await got(url);
     zipball_url = JSON.parse(response.body).assets[0].browser_download_url;
     console.log(zipball_url)
   } catch (error) {
-    console.error('Problem parsing github JSON',error);
-    throw new Error(error);
+    console.error('Unable to download from specified site. Make sure your internet is on. If it is on but this error repeats, ask for help on the Pushkin forum.');
+    throw error;
   }
   sa
     .get(zipball_url)

--- a/src/commands/sites/index.js
+++ b/src/commands/sites/index.js
@@ -7,6 +7,7 @@ import got from 'got';
 import * as compose from 'docker-compose'
 const exec = util.promisify(require('child_process').exec);
 import { templates } from './templates.js';
+import { execSync } from 'child_process'; // eslint-disable-line
 const shell = require('shelljs');
 import pacMan from '../../pMan.js';  //which package manager is available?
 
@@ -23,17 +24,22 @@ export function listSiteTemplates() {
 }
 
 export const promiseFolderInit = async (initDir, dir) => {
-  console.log(`Installing npm dependencies for ${dir}`);
-  const { stdout, stderr } = await exec(pacMan.concat(' install'), { cwd: path.join(initDir, dir) }) //this may not work on Windows
-  if (stderr) console.log(stderr);
-  console.log(`Building ${dir}`);
-  const { stdout2, stderr2 } = await exec(pacMan.concat(' run build'), { cwd: path.join(initDir, dir) }) //this may not work on Windows
-  if (stderr2) {
-    console.log(stderr2)
-  }
-  console.log(`${dir} is built`);
   return new Promise ((resolve, reject) => {
-    resolve("built")
+    console.log(`Installing dependencies for ${dir}`);
+    try {
+      exec(pacMan.concat(' install'), { cwd: path.join(initDir, dir) })
+        .then(() => {
+          console.log(`Building ${dir}`);
+          exec(pacMan.concat(' run build'), { cwd: path.join(initDir, dir) })
+            .then(() => {
+              console.log(`${dir} is built`);
+              resolve("built")              
+            })
+        })
+    } catch(e) {
+      console.error('Problem installing dependencies for ${dir}')
+      throw(e)
+    }
   })
 }
 

--- a/src/commands/sites/index.js
+++ b/src/commands/sites/index.js
@@ -20,7 +20,7 @@ export const promiseFolderInit = async (initDir, dir) => {
   return new Promise ((resolve, reject) => {
     console.log(`Installing dependencies for ${dir}`);
     try {
-      exec(pacMan.concat(' install'), { cwd: path.join(initDir, dir) })
+      exec(pacMan.concat(' install --mutex network'), { cwd: path.join(initDir, dir) })
         .then(() => {
           console.log(`Building ${dir}`);
           exec(pacMan.concat(' run build'), { cwd: path.join(initDir, dir) })

--- a/src/commands/sites/templates.js
+++ b/src/commands/sites/templates.js
@@ -1,3 +1,3 @@
-export const templates = [
-  { name: 'default', url: 'https://api.github.com/repos/pushkin-consortium/pushkin-sitetemplates-default/releases/latest' },
-];
+export const templates = {
+   'default':'https://api.github.com/repos/pushkin-consortium/pushkin-sitetemplates-default/releases'
+};

--- a/src/index.js
+++ b/src/index.js
@@ -106,12 +106,12 @@ const handleInstall = async (what) => {
         { type: 'list', name: 'experiments', choices: expList, default: 0, message: 'Which site template do you want to use?'}
         ]).then(answers => {
           let expType = answers.experiments
-          console.log(expType)
           inquirer.prompt([
             { type: 'input', name: 'name', message: 'What do you want to call your experiment?'}]).then(async (answers) => {
+              const longName = answers.name
+              const shortName = longName.replace(/[^\w\s]/g, "").replace(/ /g,"_");
               let config = await loadConfig('pushkin.yaml');
-              console.log(expType)
-              getExpTemplate(path.join(process.cwd(), config.experimentsDir), expType, answers.name)
+              getExpTemplate(path.join(process.cwd(), config.experimentsDir), expType, longName, shortName, process.cwd())
             })
       })
   } 

--- a/src/index.js
+++ b/src/index.js
@@ -212,7 +212,7 @@ async function main() {
       moveToProjectRoot();
       if (options.nocache){
         try {
-          await compose.buildAll({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml', log: true, commandOptions: ["--no-cache"]})    
+          await compose.buildAll({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml', log: true, commandOptions: ["--no-cache", "--remove-orphans"]})    
         } catch (e) {
           console.error("Problem rebuilding docker images");
           throw e;

--- a/src/index.js
+++ b/src/index.js
@@ -212,18 +212,18 @@ async function main() {
       moveToProjectRoot();
       if (options.nocache){
         try {
-          await compose.buildAll({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml', log: true, commandOptions: ["--no-cache", "--remove-orphans"]})    
+          await compose.buildAll({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml', log: true, commandOptions: ["--no-cache"]})    
         } catch (e) {
           console.error("Problem rebuilding docker images");
           throw e;
         }
-        compose.upAll({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml', log: true})
+        compose.upAll({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml', log: true, commandOptions: ["--remove-orphans"]})
           .then(
             out => { console.log(out.out, 'Starting. You may not be able to load localhost for a minute or two.')},
             err => { console.log('something went wrong:', err.message)}
           );
       } else {
-        compose.upAll({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml', log: true, commandOptions: ["--build"]})
+        compose.upAll({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml', log: true, commandOptions: ["--build","--remove-orphans"]})
           .then(
             out => { console.log(out.out, 'Starting. You may not be able to load localhost for a minute or two.')},
             err => { console.log('something went wrong:', err.message)}

--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,12 @@ async function main() {
     .description(`Install template website ('site') or experiment ('experiment').`)
     .action((what) => {
       if (what == 'site' | what == 'experiment'){
-        handleInstall(what)  
+        try {
+          handleInstall(what)  
+        } catch(e) {
+          console.error(e)
+          process.exit()
+        }
       }else{
         console.error(`Command not recognized. Run 'pushkin --help' for help.`)
       }
@@ -184,12 +189,17 @@ async function main() {
     .option('-nm, --nomigrations', 'Do not run migrations. Be sure database structure has not changed!', false)
     .action(async (options) => {
       let awaits
-      if (options.nomigrations){
-        //only running prep
-        awaits = [handlePrep()]
-      } else {
-        //running prep and updated DB
-        awaits = [handlePrep(), handleUpdateDB()];
+      try{
+        if (options.nomigrations){
+          //only running prep
+          awaits = [handlePrep()]
+        } else {
+          //running prep and updated DB
+          awaits = [handlePrep(), handleUpdateDB()];
+        }
+      } catch (e) {
+        console.error(e)
+        process.exit();
       }
       return await Promise.all(awaits);
     })

--- a/src/index.js
+++ b/src/index.js
@@ -251,6 +251,12 @@ async function main() {
     .option('-nc, --nocache', 'Rebuild all images from scratch, without using the cache.', false)
     .action(async (options) => {
       moveToProjectRoot();
+      try {
+        fs.copyFileSync('pushkin/front-end/src/experiments.js', 'pushkin/front-end/experiments.js');
+      } catch (e) {
+        console.error("Couldn't copy experiments.js. Make sure it exists and is in the right place.")
+        process.exit();
+      }
       if (options.nocache){
         try {
           await compose.buildAll({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml', log: true, commandOptions: ["--no-cache"]})    
@@ -260,7 +266,9 @@ async function main() {
         }
         compose.upAll({cwd: path.join(process.cwd(), 'pushkin'), config: 'docker-compose.dev.yml', log: true, commandOptions: ["--remove-orphans"]})
           .then(
-            out => { console.log(out.out, 'Starting. You may not be able to load localhost for a minute or two.')},
+            out => { 
+              console.log(out.out, 'Starting. You may not be able to load localhost for a minute or two.')
+            },
             err => { console.log('something went wrong:', err.message)}
           );
       } else {


### PR DESCRIPTION
Updates (includes some breaking changes relative to 1.0.0 -- I know, but nobody was using 1.1.0 and it seemed silly to move immediately to v2):

- local experiment packages now installed through `yalc`, rather than using `npm pack`. This greatly simplifies updating the packages during `pushkin prep`.
- refactored experiment installation to minimize recompilation during `pushkin prep`. Local experiment packages are installed and `controllers.js` created during `install`, and are not revised during `prep`. (`experiments.js` is still deleted and recreated in order to handle updates in the experiment configs.)
- experiments.js is now assumed to be in `pushkin/front-end` not `pushkin/front-end/src`. This allows for much better Docker cacheing. 
- Some changes to the formatting of `docker-compose`, `experiments.js`, and `controllers.js` to allow for somewhat streamlined processing.